### PR TITLE
Fix metadata deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ tests/node_modules
 tests/downloads
 target
 
+*.sh
+
 .DS_Store

--- a/mb-nft-v2/src/burning.rs
+++ b/mb-nft-v2/src/burning.rs
@@ -45,9 +45,6 @@ impl MintbaseStore {
             if count > 1 {
                 minting_metadata.burned += 1;
                 self.token_metadata.insert(&metadata_id, &minting_metadata);
-            } else {
-                self.token_metadata.remove(&metadata_id);
-                self.token_royalty.remove(&metadata_id);
             }
 
             set_owned.remove(&token_id_tuple);

--- a/mb-nft-v2/src/burning.rs
+++ b/mb-nft-v2/src/burning.rs
@@ -53,7 +53,7 @@ impl MintbaseStore {
                 .tokens
                 .get(&metadata_id)
                 .expect("This metadata does not yet exist in storage!");
-            metadata_tokens.remove(&token_id);
+            metadata_tokens.insert(&token_id, &None);
             self.tokens.insert(&metadata_id, &metadata_tokens);
         });
 

--- a/mb-nft-v2/src/core.rs
+++ b/mb-nft-v2/src/core.rs
@@ -311,6 +311,9 @@ impl MintbaseStore {
             .unwrap_or_else(|| {
                 panic!("token: {}:{} doesn't exist", token_id.0, token_id.1)
             })
+            .unwrap_or_else(|| {
+                panic!("token: {}:{} was burned", token_id.0, token_id.1)
+            })
     }
 
     /// Gets the token as specified by relevant NEPs.
@@ -321,6 +324,7 @@ impl MintbaseStore {
         self.tokens
             .get(&token_id.0)
             .and_then(|metadata_tokens| metadata_tokens.get(&token_id.1))
+            .and_then(|x| x)
             .map(|x| {
                 let token_id_string = fmt_token_id(*token_id);
                 let metadata = self.nft_token_metadata(token_id_string.clone());

--- a/mb-nft-v2/src/lib.rs
+++ b/mb-nft-v2/src/lib.rs
@@ -83,7 +83,7 @@ pub struct MintbaseStore {
     /// the number reaches zero (ie, when tokens are burnt).
     pub token_royalty: LookupMap<u64, Royalty>,
     /// Tokens this Store has minted, excluding those that have been burned.
-    pub tokens: TreeMap<u64, TreeMap<u64, Token>>,
+    pub tokens: TreeMap<u64, TreeMap<u64, Option<Token>>>,
     /// A mapping from each user to the tokens owned by that user. The owner
     /// of the token is also stored on the token itself.
     pub tokens_per_owner: LookupMap<AccountId, UnorderedSet<(u64, u64)>>,
@@ -282,7 +282,7 @@ impl MintbaseStore {
             .tokens
             .get(&metadata_id)
             .expect("This metadata does not yet exist in storage!");
-        metadata_tokens.insert(&token_id, token);
+        metadata_tokens.insert(&token_id, &Some(token.clone()));
         self.tokens.insert(&metadata_id, &metadata_tokens);
     }
 }

--- a/mb-nft-v2/src/minting.rs
+++ b/mb-nft-v2/src/minting.rs
@@ -663,6 +663,7 @@ impl MintbaseStore {
         num_to_mint: Option<u16>,
         token_ids: Option<Vec<U64>>,
     ) -> (u16, Vec<u64>) {
+        // FIXME: should never reuse a token ID!
         let metadata_tokens = self
             .tokens
             .get(&metadata_id)
@@ -707,7 +708,7 @@ impl MintbaseStore {
     fn process_tokens_ids_arg(
         &self,
         metadata_id: u64,
-        metadata_tokens: &TreeMap<u64, Token>,
+        metadata_tokens: &TreeMap<u64, Option<Token>>,
         token_ids: Vec<U64>,
     ) -> Vec<u64> {
         token_ids


### PR DESCRIPTION
- Metadata is no longer deleted when the last token is burnt, since it might still be mintable.
- Token IDs are no longer reused, as this would interfere with the indexer.